### PR TITLE
do not add newline for each function in `=> => =>` scenarios

### DIFF
--- a/scalariform/src/main/scala/com/danieltrinh/scalariform/formatter/ExprFormatter.scala
+++ b/scalariform/src/main/scala/com/danieltrinh/scalariform/formatter/ExprFormatter.scala
@@ -1,5 +1,7 @@
 package com.danieltrinh.scalariform.formatter
 
+import com.danieltrinh.scalariform.formatter.Alignment._
+import com.danieltrinh.scalariform.formatter.AnnotationFormatter
 import com.danieltrinh.scalariform.lexer.Chars
 import com.danieltrinh.scalariform.lexer.Token
 import com.danieltrinh.scalariform.lexer.Tokens._
@@ -7,7 +9,6 @@ import com.danieltrinh.scalariform.parser._
 import com.danieltrinh.scalariform.utils.{ TextEditProcessor, Utils }
 import com.danieltrinh.scalariform.formatter.preferences._
 import scala.PartialFunction._
-import Alignment._
 
 trait ExprFormatter { self: HasFormattingPreferences with AnnotationFormatter with HasHiddenTokenInfo with TypeFormatter with TemplateFormatter with ScalaFormatter with XmlFormatter with CaseClauseFormatter ⇒
 
@@ -756,8 +757,16 @@ trait ExprFormatter { self: HasFormattingPreferences with AnnotationFormatter wi
           if (statSeq.firstTokenOption.isDefined) {
             statSeq.firstStatOpt match {
               case Some(Expr(List(anonFn @ AnonymousFunction(params, arrowToken, subStatSeq)))) ⇒
+                def hasNestedAnonymousFunction(subStatSeq: StatSeq): Boolean =
+                  (for {
+                    firstStat <- subStatSeq.firstStatOpt
+                    head <- firstStat.immediateChildren.headOption
+                  } yield head.isInstanceOf[AnonymousFunction]).getOrElse(false)
+
                 val (instruction, subStatState) =
-                  if (hiddenPredecessors(params(0).firstToken).containsNewline)
+                  if (hasNestedAnonymousFunction(subStatSeq))
+                    (CompactEnsuringGap, indentedState.indent(-1))
+                  else if (hiddenPredecessors(params(0).firstToken).containsNewline)
                     (indentedInstruction, indentedState.indent)
                   else
                     (CompactEnsuringGap, indentedState)
@@ -765,7 +774,9 @@ trait ExprFormatter { self: HasFormattingPreferences with AnnotationFormatter wi
                 formatResult ++= format(params)
                 for (firstToken ← subStatSeq.firstTokenOption) {
                   val instruction =
-                    if (hiddenPredecessors(firstToken).containsNewline || containsNewline(subStatSeq))
+                    if (hasNestedAnonymousFunction(subStatSeq))
+                      CompactEnsuringGap
+                    else if (hiddenPredecessors(firstToken).containsNewline || containsNewline(subStatSeq))
                       statFormatterState(subStatSeq.firstStatOpt)(subStatState).currentIndentLevelInstruction
                     else
                       CompactEnsuringGap

--- a/scalariform/src/test/scala/com/danieltrinh/scalariform/formatter/FunctionFormatterTest.scala
+++ b/scalariform/src/test/scala/com/danieltrinh/scalariform/formatter/FunctionFormatterTest.scala
@@ -1,0 +1,46 @@
+package com.danieltrinh.scalariform.formatter
+
+import com.danieltrinh.scalariform.parser.{CompilationUnit, ScalaParser}
+
+// format: OFF
+class FunctionFormatterTest extends AbstractFormatterTest {
+
+  "val f = x   =>  x" ==> "val f = x => x"
+  "val f: Int => Int => Unit = a => b => ()" ==> "val f: Int => Int => Unit = a => b => ()"
+
+  "{ ctx => j => () }" ==> "{ ctx => j => () }"
+  "fun { ctx => j => () }" ==> "fun { ctx => j => () }"
+  "Thing() { ctx => j => () }" ==> "Thing() { ctx => j => () }"
+
+  """{ ctx =>
+    |  ???
+    |}""".stripMargin ==>
+  """{ ctx =>
+    |  ???
+    |}""".stripMargin
+  
+  """{ ctx => j =>
+    |  ???
+    |}""".stripMargin ==>
+  """{ ctx => j =>
+    |  ???
+    |}""".stripMargin
+
+  """val  x  = {  ctx   =>   j   =>
+    |    one()
+    |      two()
+    |}""".stripMargin ==>
+  """val x = { ctx => j =>
+    |  one()
+    |  two()
+    |}""".stripMargin
+
+  override val debug = false
+
+  type Result = CompilationUnit
+
+  def parse(parser: ScalaParser) = parser.compilationUnitOrScript()
+  
+  def format(formatter: ScalaFormatter, result: Result) = formatter.format(result)(FormatterState())
+
+}


### PR DESCRIPTION
This PR solves #45 in which taking functions such as:

```scala
thing { f => x =>
  // ...
}
```

does not result in being forced to have a newline in there:

```scala
// current style forced by scalariform
thing { f => 
  x =>
    // ...
}

// wanted style, shorter, less indents:
thing { f => x => 
  // ..
}
```

I'm happy to shuffle code around if you'd like me to comply to some style or hide this style behind a flag - let me know what works for you. Would definitely like to bring this in as it would make akka-streams apis so much nicer when used with scalariform.