### PR TITLE
Fix Scala Style Guide table in README

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -555,9 +555,9 @@ initially compliant with the Style Guide will not become uncompliant
 after formatting. In a number of cases, running the formatter will
 make uncompliant source more compliant.
 
-============================                ========= =========
+=========================================== ========= =========
 Preference                                  Value     Default?
-============================                ========= =========
+=========================================== ========= =========
 alignParameters                             ``false``
 compactStringConcatenation                  ``false``
 doubleIndentClassDeclaration                ``true``    No
@@ -568,7 +568,7 @@ rewriteArrowSymbols                         ``false``
 spaceBeforeColon                            ``false``
 spaceInsideBrackets                         ``false``
 spaceInsideParentheses                      ``false``
-============================                ========= =========
+=========================================== ========= =========
 
 Source Directives
 -----------------


### PR DESCRIPTION
The table was broken in commit a6478473 and has been omitted from the rendered README on GitHub since then.

Try http://rst.ninjs.org/ for an online reStructuredText editor.