### PR TITLE
Add some comments and tests for SpacesAroundMultiImports

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -541,10 +541,18 @@ Default: ``true``
 Whether or not to add spaces around multi-imports. For example, if ``true``, then::
 
   import a.{ b, c, d }
+  import foo.{ bar => baz }
 
 If ``false``, then::
 
   import a.{b,c,d}
+  import foo.{bar => baz}
+
+The default is ``true`` for backwards-compatibility with older versions of `Scalariform`,
+but the standard Scala formatting requires ``false``.
+
+See the examples given in "Chapter 13 - Packages and Imports.", page 244 of *Programming in Scala*
+2nd ed. (2010) by Odersky, Spoon and Venners.
 
 Scala Style Guide
 ~~~~~~~~~~~~~~~~~
@@ -568,6 +576,7 @@ rewriteArrowSymbols                         ``false``
 spaceBeforeColon                            ``false``
 spaceInsideBrackets                         ``false``
 spaceInsideParentheses                      ``false``
+spacesAroundMultiImports                    ``false``   No
 =========================================== ========= =========
 
 Source Directives

--- a/README.rst
+++ b/README.rst
@@ -555,9 +555,9 @@ initially compliant with the Style Guide will not become uncompliant
 after formatting. In a number of cases, running the formatter will
 make uncompliant source more compliant.
 
-============================                ========= =========
+=========================================== ========= =========
 Preference                                  Value     Default?
-============================                ========= =========
+=========================================== ========= =========
 alignParameters                             ``false``
 compactStringConcatenation                  ``false``
 doubleIndentClassDeclaration                ``true``    No
@@ -568,7 +568,7 @@ rewriteArrowSymbols                         ``false``
 spaceBeforeColon                            ``false``
 spaceInsideBrackets                         ``false``
 spaceInsideParentheses                      ``false``
-============================                ========= =========
+=========================================== ========= =========
 
 Source Directives
 -----------------

--- a/README.rst
+++ b/README.rst
@@ -536,19 +536,20 @@ If ``false``,::
 spacesAroundMultiImports
 ~~~~~~~~~~~~~~~~~~~~~~~~
 
-Default: ``true``
+Default: ``false``
 
-Whether or not to add spaces around multi-imports. For example, if ``true``, then::
-
-  import a.{ b, c, d }
-  import foo.{ bar => baz }
-
-If ``false``, then::
+Whether or not to add spaces around multi-imports.
+For example, if ``false``, then::
 
   import a.{b,c,d}
   import foo.{bar => baz}
 
-The default is ``true`` for backwards-compatibility with older versions of `Scalariform`,
+If ``true``, then::
+
+  import a.{ b, c, d }
+  import foo.{ bar => baz }
+
+Older versions of `Scalariform` used ``true``,
 but the standard Scala formatting requires ``false``.
 
 See the examples given in "Chapter 13 - Packages and Imports.", page 244 of *Programming in Scala*
@@ -576,7 +577,7 @@ rewriteArrowSymbols                         ``false``
 spaceBeforeColon                            ``false``
 spaceInsideBrackets                         ``false``
 spaceInsideParentheses                      ``false``
-spacesAroundMultiImports                    ``false``   No
+spacesAroundMultiImports                    ``false``
 =========================================== ========= =========
 
 Source Directives

--- a/scalariform/src/main/scala/com/danieltrinh/scalariform/formatter/ExprFormatter.scala
+++ b/scalariform/src/main/scala/com/danieltrinh/scalariform/formatter/ExprFormatter.scala
@@ -1319,17 +1319,27 @@ trait ExprFormatter { self: HasFormattingPreferences with AnnotationFormatter wi
   private def format(blockImportExpr: BlockImportExpr)(implicit formatterState: FormatterState): FormatResult = {
     val BlockImportExpr(prefixExpr, importSelectors @ ImportSelectors(lbrace, firstImportSelector: Expr, otherImportSelectors: List[(Token, Expr)], rbrace)) = blockImportExpr
     var formatResult: FormatResult = NoFormatResult
+
     formatResult ++= format(prefixExpr)
 
     val singleLineBlock = !containsNewline(importSelectors)
     val newFormatterState = formatterState.copy(inSingleLineBlock = singleLineBlock)
 
     if (singleLineBlock) {
+      // We are in a braced import statement like "import foo.{bar=>baz}"
+      // or "import foo.{a,b,c}".
+      // The default formatting instruction for a LBRACE is "CompactEnsuringGap"
+      // (See ScalaFormatter.actualDefaultFormattingInstruction), so if we don't
+      // emit an overriding instruction here, then a space will be inserted.
+      // That's against the Scala Style Guide, so we need to use the extra
+      // context we have at this time to mark this as not a normal LBRACE.
       if (!formattingPreferences(SpacesAroundMultiImports))
         formatResult = formatResult.before(firstImportSelector.firstToken, Compact)
+
       formatResult ++= format(firstImportSelector)
       for ((comma, otherImportSelector) ← otherImportSelectors)
         formatResult ++= format(otherImportSelector)
+
       if (!formattingPreferences(SpacesAroundMultiImports))
         formatResult = formatResult.before(rbrace, Compact)
     } else {

--- a/scalariform/src/main/scala/com/danieltrinh/scalariform/formatter/preferences/PreferenceDescriptor.scala
+++ b/scalariform/src/main/scala/com/danieltrinh/scalariform/formatter/preferences/PreferenceDescriptor.scala
@@ -210,5 +210,5 @@ case object PlaceScaladocAsterisksBeneathSecondAsterisk extends BooleanPreferenc
 case object SpacesAroundMultiImports extends BooleanPreferenceDescriptor {
   val key = "spacesAroundMultiImports"
   val description = "Place spaces around multi imports (import a.{ b, c, d }"
-  val defaultValue = true
+  val defaultValue = false
 }

--- a/scalariform/src/test/scala/com/danieltrinh/scalariform/formatter/ImportFormatterTest.scala
+++ b/scalariform/src/test/scala/com/danieltrinh/scalariform/formatter/ImportFormatterTest.scala
@@ -7,24 +7,36 @@ import scalariform.formatter.preferences.{SpacesAroundMultiImports, FormattingPr
 // format: OFF
 class ImportFormatterTest extends AbstractFormatterTest {
 
-  "import foo . _" ==> "import foo._" 
-  "import foo . bar" ==> "import foo.bar" 
-  "import foo.{bar=>baz}" ==> "import foo.{ bar => baz }"
-  "import foo.{bar=>baz},baz.biz" ==> "import foo.{ bar => baz }, baz.biz"
+  {
+    implicit val formattingPreferences = FormattingPreferences.setPreference(
+      SpacesAroundMultiImports, true)
 
-  """import foo.{bar => baz,
-    |wibble => wobble}""" ==>
-  """import foo.{
-    |  bar => baz,
-    |  wibble => wobble
-    |}"""
-
+    "import foo . _" ==> "import foo._"
+    "import foo . bar" ==> "import foo.bar"
+    "import foo.{bar=>baz}" ==> "import foo.{ bar => baz }"
+    "import foo.{bar=>baz},baz.biz" ==> "import foo.{ bar => baz }, baz.biz"
+    """import foo.{bar => baz,
+        |wibble => wobble}""" ==>
+      """import foo.{
+        |  bar => baz,
+        |  wibble => wobble
+        |}"""
+  }
 
   {
-    implicit val formattingPreferences = FormattingPreferences.setPreference(SpacesAroundMultiImports, false)
+    implicit val formattingPreferences = FormattingPreferences.setPreference(
+      SpacesAroundMultiImports, false)
 
+    "import foo . _" ==> "import foo._"
+    "import foo . bar" ==> "import foo.bar"
     "import foo.{bar=>baz}" ==> "import foo.{bar => baz}"
     "import foo.{bar=>baz},baz.biz" ==> "import foo.{bar => baz}, baz.biz"
+    """import foo.{bar => baz,
+      |wibble => wobble}""" ==>
+      """import foo.{
+        |  bar => baz,
+        |  wibble => wobble
+        |}"""
   }
 
   override val debug = false


### PR DESCRIPTION
Minor changes relating to the "SpacesAroundMultiImports" setting.

The default for this is "true", but I think that the standard Scala style is "false". We probably need to keep "true" for back-compatibility, and I've added comments to explain that (although I'd be happy if you wanted to change to "false").

This isn't explicitly covered in the Scala Style Guide, so I've added a cite from *Programming in Scala*
by Odersky to justify it.

(This includes #57, as it conflicts with it if pulled separately.)