### PR TITLE
Parse <: as SUBTYPE in scala 2.10.5

### DIFF
--- a/project/Build.scala
+++ b/project/Build.scala
@@ -27,10 +27,10 @@ object ScalariformBuild extends Build {
     organization := "org.scalariform",
     profileName := "org.scalariform",
     version := "0.1.6",
-    scalaVersion := "2.10.4",
+    scalaVersion := "2.10.5",
     crossScalaVersions := Seq(
       "2.11.6",
-      "2.10.4",
+      "2.10.5",
       "2.9.3", "2.9.2" //"2.9.1-1", "2.9.1", "2.9.0-1", "2.9.0"
     ),
     exportJars := true, // Needed for cli oneJar

--- a/scalariform/src/main/scala/com/danieltrinh/scalariform/lexer/ScalaOnlyLexer.scala
+++ b/scalariform/src/main/scala/com/danieltrinh/scalariform/lexer/ScalaOnlyLexer.scala
@@ -42,7 +42,7 @@ private[lexer] trait ScalaOnlyLexer { self: ScalaLexer ⇒
           possibleInterpolationId = false
       case '<' ⇒
         lastCh match {
-          case SU | ' ' | '\t' | '\n' | '{' | '(' | '>' if ch(1) != SU && (isNameStart(ch(1)) || ch(1) == '!' || ch(1) == '?') ⇒
+          case SU | ' ' | '\t' | '\n' | '{' | '(' | '>' if ch(1) != SU && ch(1) != ':' && (isNameStart(ch(1)) || ch(1) == '!' || ch(1) == '?') ⇒
             switchToXmlModeAndFetchToken()
           case _ ⇒
             nextChar()

--- a/scalariform/src/test/scala/com/danieltrinh/scalariform/lexer/ScalaLexerTest.scala
+++ b/scalariform/src/test/scala/com/danieltrinh/scalariform/lexer/ScalaLexerTest.scala
@@ -155,6 +155,7 @@ println("foo")""" producesTokens (VARID, LPAREN, STRING_LITERAL, RPAREN, WS, VAR
   "\"\\u0061\"" producesTokens (STRING_LITERAL)
   "\"\\u000a\"" producesTokens (STRING_LITERAL)
 
+  "<:" producesTokens (SUBTYPE)
   "<foo />" producesTokens (XML_START_OPEN, XML_NAME, XML_WHITESPACE, XML_EMPTY_CLOSE)
   "<foo></foo>" producesTokens (XML_START_OPEN, XML_NAME, XML_TAG_CLOSE, XML_END_OPEN, XML_NAME, XML_TAG_CLOSE)
   "<foo></foo  >" producesTokens (XML_START_OPEN, XML_NAME, XML_TAG_CLOSE, XML_END_OPEN, XML_NAME, XML_WHITESPACE, XML_TAG_CLOSE)


### PR DESCRIPTION
Noticed this in the context of [this scalastyle bug](https://github.com/scalastyle/scalastyle/issues/156) and [this sbt bug](https://github.com/sbt/sbt/issues/2089). The upgrade to 2.10.5 isn't strictly necessary, but the additional test doesn't fail unless the scala version is 2.10.5.