### PR TITLE
correct checkFile exit status

### DIFF
--- a/cli/src/main/scala/com/danieltrinh/scalariform/commandline/Main.scala
+++ b/cli/src/main/scala/com/danieltrinh/scalariform/commandline/Main.scala
@@ -272,7 +272,7 @@ object Main {
     }
     val padding = " " * (6 - resultString.length)
     log("[" + resultString + "]" + padding + " " + file)
-    formatResult != FormattedCorrectly
+    formatResult == FormattedCorrectly
   }
 
   /**


### PR DESCRIPTION
Fix checkFile to uphold its contract "return true iff the file was already formatted correctly". This fixes a related bug where a successful invocation of --test on the cli will return 1, breaking scripts and making everyone :sob: .