### PR TITLE
Fix multi-line argument lists when IndentWithTabs is enabled.

### DIFF
--- a/scalariform/src/main/scala/com/danieltrinh/scalariform/formatter/ExprFormatter.scala
+++ b/scalariform/src/main/scala/com/danieltrinh/scalariform/formatter/ExprFormatter.scala
@@ -392,14 +392,15 @@ trait ExprFormatter { self: HasFormattingPreferences with AnnotationFormatter wi
           // If there's a newline before this argument, OR there will be a newline after formatting
           if (hiddenPredecessors(firstToken).containsNewline || formatResult.tokenWillHaveNewline(firstToken)) {
             formatResult = formatResult.before(firstToken, argumentFormatterState.nextIndentLevelInstruction)
-            formatResult = formatResult.before(
-              expr.equals,
-              PlaceAtColumn(
-                0,
-                maxIdLength + 1,
-                Some(firstToken)
+            if (!formattingPreferences(IndentWithTabs))
+              formatResult = formatResult.before(
+                expr.equals,
+                PlaceAtColumn(
+                  0,
+                  maxIdLength + 1,
+                  Some(firstToken)
+                )
               )
-            )
           }
         }
       case Right(callExpr) ⇒

--- a/scalariform/src/test/scala/com/danieltrinh/scalariform/formatter/IndentWithTabsTest.scala
+++ b/scalariform/src/test/scala/com/danieltrinh/scalariform/formatter/IndentWithTabsTest.scala
@@ -42,6 +42,26 @@ class IndentWithTabsTest extends AbstractFormatterTest {
     |	bar
     |</foo>"""
 
+  """foo(
+    |alpha = "foo",
+    |beta = "bar",
+    |gamma = false)""" ==>
+  """foo(
+    |	alpha = "foo",
+    |	beta = "bar",
+    |	gamma = false
+    |)"""
+
+  """foo(
+    |"foo",
+    |"bar",
+    |false)""" ==>
+  """foo(
+    |	"foo",
+    |	"bar",
+    |	false
+    |)"""
+
 
   override val debug = false
 


### PR DESCRIPTION
This Pull Request fixes https://github.com/daniel-trinh/scalariform/issues/63.