### PR TITLE
Add a new DanglingCloseParenthesis option to restore old dangling parenthesis behaviors.

### DIFF
--- a/misc/src/main/scala/com/danieltrinh/scalariform/gui/FormatterFrame.scala
+++ b/misc/src/main/scala/com/danieltrinh/scalariform/gui/FormatterFrame.scala
@@ -225,7 +225,7 @@ class FormatterFrame extends JFrame with SpecificFormatter {
   add(splitPane, BorderLayout.CENTER)
 
   object OptionsPanel extends JPanel(new MigLayout) {
-    def addChangeListener(box: JCheckBox) {
+    def addChangeListener(box: JToggleButton) {
       box.addItemListener(new ItemListener() {
         def itemStateChanged(e: ItemEvent) {
           runFormatter()
@@ -245,6 +245,30 @@ class FormatterFrame extends JFrame with SpecificFormatter {
             add(checkBox, new CC().wrap)
             addChangeListener(checkBox)
             preferenceToWidgetMap += (preference -> checkBox)
+          case IntentPreference ⇒
+            val radioPanel = new JPanel(new GridLayout(0, 1));
+            val radioGroup = new ButtonGroup()
+            val radioForce = new JRadioButton("force")
+            val radioPrevent = new JRadioButton("prevent")
+            val radioPreserve = new JRadioButton("preserve")
+            radioGroup.add(radioForce)
+            radioGroup.add(radioPrevent)
+            radioGroup.add(radioPreserve)
+            radioPanel.add(radioForce)
+            radioPanel.add(radioPrevent)
+            radioPanel.add(radioPreserve)
+            preference.defaultValue.asInstanceOf[Intent] match {
+              case Force ⇒ radioForce.setSelected(true)
+              case Prevent ⇒ radioPrevent.setSelected(true)
+              case Preserve ⇒ radioPreserve.setSelected(true)
+            }
+            add(radioForce, new CC().wrap)
+            add(radioPrevent, new CC().wrap)
+            add(radioPreserve, new CC().wrap)
+            addChangeListener(radioForce)
+            addChangeListener(radioPrevent)
+            addChangeListener(radioPreserve)
+            preferenceToWidgetMap += (preference -> radioPanel)
           case IntegerPreference(min, max) ⇒
             val label = new JLabel(preference.description)
             add(label, new CC)
@@ -294,6 +318,11 @@ class FormatterFrame extends JFrame with SpecificFormatter {
             preferences = preferences.setPreference(prefType.cast(preference), widget.asInstanceOf[JCheckBox].isSelected)
           case prefType @ IntegerPreference(min, max) ⇒
             preferences = preferences.setPreference(prefType.cast(preference), Integer.parseInt(widget.asInstanceOf[JSpinner].getValue.toString))
+          case prefType @ IntentPreference ⇒
+            val selected = widget.asInstanceOf[JPanel].getComponents.find(_.asInstanceOf[JRadioButton].isSelected).get.getName
+            preferences = preferences.setPreference(
+				  prefType.asInstanceOf[PreferenceDescriptor[Object]],
+				  IntentPreference.parseValue(selected))
         }
       }
       preferences

--- a/scalariform/src/main/scala/com/danieltrinh/scalariform/formatter/ExprFormatter.scala
+++ b/scalariform/src/main/scala/com/danieltrinh/scalariform/formatter/ExprFormatter.scala
@@ -302,9 +302,14 @@ trait ExprFormatter { self: HasFormattingPreferences with AnnotationFormatter wi
       formatResult ++= alignedFormatResult
       val firstTokenIsOnNewline = contents.headOption.exists { x ⇒
         val firstToken = x.firstToken
-        hiddenPredecessors(firstToken).containsNewline || formatResult.tokenWillHaveNewline(firstToken)
+        val forceNewline = formattingPreferences(DanglingCloseParenthesis) == Force
+        forceNewline && (hiddenPredecessors(firstToken).containsNewline || formatResult.tokenWillHaveNewline(firstToken))
       }
-      if (firstTokenIsOnNewline)
+      val shouldPreserveNewline =
+        (formattingPreferences(DanglingCloseParenthesis) == Preserve) &&
+        hiddenPredecessors(rparen).containsNewline &&
+        contents.nonEmpty
+      if (firstTokenIsOnNewline || shouldPreserveNewline)
         formatResult = formatResult.before(rparen, formatterState.currentIndentLevelInstruction)
 
       (formatResult, currentFormatterState)

--- a/scalariform/src/main/scala/com/danieltrinh/scalariform/formatter/ExprFormatter.scala
+++ b/scalariform/src/main/scala/com/danieltrinh/scalariform/formatter/ExprFormatter.scala
@@ -303,7 +303,8 @@ trait ExprFormatter { self: HasFormattingPreferences with AnnotationFormatter wi
       val firstTokenIsOnNewline = contents.headOption.exists { x ⇒
         val firstToken = x.firstToken
         val forceNewline = formattingPreferences(DanglingCloseParenthesis) == Force
-        forceNewline && (hiddenPredecessors(firstToken).containsNewline || formatResult.tokenWillHaveNewline(firstToken))
+        hiddenPredecessors(rparen).containsComment ||
+          forceNewline && (hiddenPredecessors(firstToken).containsNewline || formatResult.tokenWillHaveNewline(firstToken))
       }
       val shouldPreserveNewline =
         (formattingPreferences(DanglingCloseParenthesis) == Preserve) &&
@@ -1170,9 +1171,10 @@ trait ExprFormatter { self: HasFormattingPreferences with AnnotationFormatter wi
     val hasContent = implicitOption.isDefined || firstParamOption.isDefined || !otherParams.isEmpty
     val firstTokenIsOnNewline = hiddenPredecessors(relativeToken).containsNewline || formatResult.tokenWillHaveNewline(relativeToken)
 
-    val shouldIndentParen = (hiddenPredecessors(rparen).containsNewline &&
+    val shouldIndentParen = hiddenPredecessors(rparen).containsComment || 
+      ((hiddenPredecessors(rparen).containsNewline &&
       formattingPreferences(DanglingCloseParenthesis) == Preserve) ||
-      formattingPreferences(DanglingCloseParenthesis) == Force
+      formattingPreferences(DanglingCloseParenthesis) == Force)
     // Place rparen on it's own line if this is a multi-line param clause
     if (firstTokenIsOnNewline && hasContent && shouldIndentParen)
       formatResult = formatResult.before(rparen, paramFormatterState.currentIndentLevelInstruction)

--- a/scalariform/src/main/scala/com/danieltrinh/scalariform/formatter/ExprFormatter.scala
+++ b/scalariform/src/main/scala/com/danieltrinh/scalariform/formatter/ExprFormatter.scala
@@ -1170,8 +1170,11 @@ trait ExprFormatter { self: HasFormattingPreferences with AnnotationFormatter wi
     val hasContent = implicitOption.isDefined || firstParamOption.isDefined || !otherParams.isEmpty
     val firstTokenIsOnNewline = hiddenPredecessors(relativeToken).containsNewline || formatResult.tokenWillHaveNewline(relativeToken)
 
+    val shouldIndentParen = (hiddenPredecessors(rparen).containsNewline &&
+      formattingPreferences(DanglingCloseParenthesis) == Preserve) ||
+      formattingPreferences(DanglingCloseParenthesis) == Force
     // Place rparen on it's own line if this is a multi-line param clause
-    if (firstTokenIsOnNewline && hasContent)
+    if (firstTokenIsOnNewline && hasContent && shouldIndentParen)
       formatResult = formatResult.before(rparen, paramFormatterState.currentIndentLevelInstruction)
 
     val groupedParams = groupParams(paramClause, alignParameters)

--- a/scalariform/src/main/scala/com/danieltrinh/scalariform/formatter/preferences/PreferenceDescriptor.scala
+++ b/scalariform/src/main/scala/com/danieltrinh/scalariform/formatter/preferences/PreferenceDescriptor.scala
@@ -8,6 +8,30 @@ sealed trait PreferenceType[T] {
 
 }
 
+/** Trinary state setting for preference which can be enforced two ways or disabled. */
+sealed trait Intent extends Product with Serializable
+
+/** Preserve the formatting choice made at the site. */
+case object Preserve extends Intent
+
+/** Force the formatting choice in the preference name. */
+case object Force extends Intent
+
+/** Prevent the formatting choice in the preference name. */
+case object Prevent extends Intent
+
+case object IntentPreference extends PreferenceType[Intent] {
+
+  def parseValue(s: String) =
+    s.toLowerCase match {
+      case "preserve"  ⇒ Right(Preserve)
+      case "force"     ⇒ Right(Force)
+      case "prevent"   ⇒ Right(Prevent)
+      case _           ⇒ Left("Could not parse as intent value: " + s)
+    }
+}
+
+
 case object BooleanPreference extends PreferenceType[Boolean] {
 
   def parseValue(s: String) =
@@ -46,6 +70,12 @@ trait PreferenceDescriptor[T] {
   val preferenceType: PreferenceType[T]
 
   val defaultValue: T
+
+}
+
+trait IntentPreferenceDescriptor extends PreferenceDescriptor[Intent] {
+
+  val preferenceType = IntentPreference
 
 }
 
@@ -155,11 +185,17 @@ case object IndentLocalDefs extends BooleanPreferenceDescriptor {
   val defaultValue = false
 }
 
-@deprecated("This has been dropped in favor of always placing ')' on a newline if the clause is multi-line.", since = "0.1.5")
+@deprecated("This has been dropped in favor of DanglingCloseParenthesis.", since = "0.1.5")
 case object PreserveDanglingCloseParenthesis extends BooleanPreferenceDescriptor {
   val key = "preserveDanglingCloseParenthesis"
   val description = "Allow a newline before a ')' in an argument expression"
   val defaultValue = false
+}
+
+case object DanglingCloseParenthesis extends IntentPreferenceDescriptor {
+  val key = "danglingCloseParenthesis"
+  val description = "Put a newline before a ')' in an argument expression"
+  val defaultValue = Force
 }
 
 case object SpaceInsideParentheses extends BooleanPreferenceDescriptor {

--- a/scalariform/src/main/scala/com/danieltrinh/scalariform/formatter/preferences/PreferenceDescriptor.scala
+++ b/scalariform/src/main/scala/com/danieltrinh/scalariform/formatter/preferences/PreferenceDescriptor.scala
@@ -93,7 +93,7 @@ object AllPreferences {
   val preferences: List[PreferenceDescriptor[_]] = List(
     RewriteArrowSymbols, IndentSpaces, SpaceBeforeColon, CompactStringConcatenation,
     PreserveSpaceBeforeArguments, AlignParameters, AlignArguments, DoubleIndentClassDeclaration, FormatXml, IndentPackageBlocks,
-    AlignSingleLineCaseStatements, AlignSingleLineCaseStatements.MaxArrowIndent, IndentLocalDefs, PreserveDanglingCloseParenthesis,
+    AlignSingleLineCaseStatements, AlignSingleLineCaseStatements.MaxArrowIndent, IndentLocalDefs, PreserveDanglingCloseParenthesis, DanglingCloseParenthesis,
     SpaceInsideParentheses, SpaceInsideBrackets, SpacesWithinPatternBinders, MultilineScaladocCommentsStartOnFirstLine, IndentWithTabs,
     CompactControlReadability, PlaceScaladocAsterisksBeneathSecondAsterisk, SpacesAroundMultiImports
   )

--- a/scalariform/src/test/scala/com/danieltrinh/scalariform/formatter/DefOrDclFormatterTest.scala
+++ b/scalariform/src/test/scala/com/danieltrinh/scalariform/formatter/DefOrDclFormatterTest.scala
@@ -157,6 +157,90 @@ class DefOrDclFormatterTest extends AbstractFormatterTest {
 
   }
 
+  {
+    implicit val formattingPreferences = FormattingPreferences.setPreference(DanglingCloseParenthesis, Preserve)
+
+    """def foo(
+      |  alpha: Int,
+      |  beta: String = "default",
+      |  gamma: Boolean = true,
+      |  delta: Boolean = false): Double = {
+      |
+      |  bar
+      |}""" ==>
+    """def foo(
+      |  alpha: Int,
+      |  beta: String = "default",
+      |  gamma: Boolean = true,
+      |  delta: Boolean = false): Double = {
+      |
+      |  bar
+      |}"""
+
+    """def foo(
+      |  alpha: Int,
+      |  beta: String = "default",
+      |  gamma: Boolean = true,
+      |  delta: Boolean = false
+      |): Double = {
+      |
+      |  bar
+      |}""" ==>
+    """def foo(
+      |  alpha: Int,
+      |  beta: String = "default",
+      |  gamma: Boolean = true,
+      |  delta: Boolean = false
+      |): Double = {
+      |
+      |  bar
+      |}"""
+  }
+
+  {
+    implicit val formattingPreferences = FormattingPreferences.setPreference(DanglingCloseParenthesis, Prevent)
+
+    """private def foo(
+      |  alpha: Int,
+      |  beta: String = "default",
+      |  gamma: Boolean = true,
+      |  delta: Boolean = false
+      |): Double = {
+      |
+      |  bar
+      |}""" ==>
+    """private def foo(
+      |  alpha: Int,
+      |  beta: String = "default",
+      |  gamma: Boolean = true,
+      |  delta: Boolean = false): Double = {
+      |
+      |  bar
+      |}"""
+  }
+
+  {
+    implicit val formattingPreferences = FormattingPreferences.setPreference(DanglingCloseParenthesis, Force)
+
+    """private def foo(
+      |  alpha: Int,
+      |  beta: String = "default",
+      |  gamma: Boolean = true,
+      |  delta: Boolean = false): Double = {
+      |
+      |  bar
+      |}""" ==>
+    """private def foo(
+      |  alpha: Int,
+      |  beta: String = "default",
+      |  gamma: Boolean = true,
+      |  delta: Boolean = false
+      |): Double = {
+      |
+      |  bar
+      |}"""
+  }
+
   """def foo(n, m)""" ==>
   """def foo(n, m)"""
 

--- a/scalariform/src/test/scala/com/danieltrinh/scalariform/formatter/DefOrDclFormatterTest.scala
+++ b/scalariform/src/test/scala/com/danieltrinh/scalariform/formatter/DefOrDclFormatterTest.scala
@@ -1,3 +1,4 @@
+
 package scalariform.formatter
 
 import scalariform.parser._
@@ -217,6 +218,29 @@ class DefOrDclFormatterTest extends AbstractFormatterTest {
       |
       |  bar
       |}"""
+
+    """case class FqnSymbol(
+      |  id: Option[Int],
+      |  file: String, // the underlying file
+      |  path: String, // the VFS handle (e.g. classes in jars)
+      |  fqn: String,
+      |  descriptor: Option[String], // for methods
+      |  internal: Option[String], // for fields
+      |  source: Option[String], // VFS
+      |  line: Option[Int],
+      |  offset: Option[Int] = None // future features:
+      |)""" ==>
+    """case class FqnSymbol(
+      |  id: Option[Int],
+      |  file: String, // the underlying file
+      |  path: String, // the VFS handle (e.g. classes in jars)
+      |  fqn: String,
+      |  descriptor: Option[String], // for methods
+      |  internal: Option[String], // for fields
+      |  source: Option[String], // VFS
+      |  line: Option[Int],
+      |  offset: Option[Int] = None // future features:
+      |)"""
   }
 
   {

--- a/scalariform/src/test/scala/com/danieltrinh/scalariform/formatter/IndentWithTabsTest.scala
+++ b/scalariform/src/test/scala/com/danieltrinh/scalariform/formatter/IndentWithTabsTest.scala
@@ -62,6 +62,111 @@ class IndentWithTabsTest extends AbstractFormatterTest {
     |	false
     |)"""
 
+  {
+    implicit val formattingPreferences = FormattingPreferences
+      .setPreference(IndentWithTabs, true)
+      .setPreference(DanglingCloseParenthesis, Force)
+
+    """foo(
+      |alpha = "foo",
+      |beta = "bar",
+      |gamma = false)""" ==>
+    """foo(
+      |	alpha = "foo",
+      |	beta = "bar",
+      |	gamma = false
+      |)"""
+
+    """foo(
+      |"foo",
+      |"bar",
+      |false)""" ==>
+    """foo(
+      |	"foo",
+      |	"bar",
+      |	false
+      |)"""
+
+    """foo(
+      |	"foo",
+      |	"bar",
+      |	false)""" ==>
+    """foo(
+      |	"foo",
+      |	"bar",
+      |	false
+      |)"""
+  }
+
+  {
+    implicit val formattingPreferences = FormattingPreferences
+      .setPreference(IndentWithTabs, true)
+      .setPreference(DanglingCloseParenthesis, Preserve)
+
+    """foo(
+      |alpha = "foo",
+      |beta = "bar",
+      |gamma = false)""" ==>
+    """foo(
+      |	alpha = "foo",
+      |	beta = "bar",
+      |	gamma = false)"""
+
+    """foo(
+      |"foo",
+      |"bar",
+      |false)""" ==>
+    """foo(
+      |	"foo",
+      |	"bar",
+      |	false)"""
+
+    """foo(
+      |	"foo",
+      |	"bar",
+      |	false)""" ==>
+    """foo(
+      |	"foo",
+      |	"bar",
+      |	false)"""
+  }
+
+  {
+    implicit val formattingPreferences = FormattingPreferences
+      .setPreference(IndentWithTabs, true)
+      .setPreference(DanglingCloseParenthesis, Prevent)
+
+    """foo(
+      |alpha = "foo",
+      |beta = "bar",
+      |gamma = false
+      |)""" ==>
+    """foo(
+      |	alpha = "foo",
+      |	beta = "bar",
+      |	gamma = false)"""
+
+    """foo(
+      |"foo",
+      |"bar",
+      |false
+      |)""" ==>
+    """foo(
+      |	"foo",
+      |	"bar",
+      |	false)"""
+
+    """foo(
+      |	"foo",
+      |	"bar",
+      |	false
+      |)""" ==>
+    """foo(
+      |	"foo",
+      |	"bar",
+      |	false)"""
+  }
+
 
   override val debug = false
 

--- a/scalariform/src/test/scala/com/danieltrinh/scalariform/formatter/ParenAndBracketSpacingTest.scala
+++ b/scalariform/src/test/scala/com/danieltrinh/scalariform/formatter/ParenAndBracketSpacingTest.scala
@@ -128,6 +128,17 @@ class ParenAndBracketSpacingTest extends AbstractExpressionFormatterTest {
       |  "foo",
       |  "bar",
       |  false)"""
+
+    """foo(
+      |alpha = "foo",
+      |beta = "bar",
+      |gamma = false // comment
+      |)""" ==>
+    """foo(
+      |  alpha = "foo",
+      |  beta = "bar",
+      |  gamma = false // comment
+      |)"""
   }
 
 }

--- a/scalariform/src/test/scala/com/danieltrinh/scalariform/formatter/ParenAndBracketSpacingTest.scala
+++ b/scalariform/src/test/scala/com/danieltrinh/scalariform/formatter/ParenAndBracketSpacingTest.scala
@@ -23,4 +23,111 @@ class ParenAndBracketSpacingTest extends AbstractExpressionFormatterTest {
     "foo[Bar][Baz][Buz]" ==> "foo[ Bar ][ Baz ][ Buz ]"
   }
 
+  {
+    implicit val formattingPreferences = FormattingPreferences.setPreference(DanglingCloseParenthesis, Force)
+    """foo(
+      |alpha = "foo",
+      |beta = "bar",
+      |gamma = false)""" ==>
+    """foo(
+      |  alpha = "foo",
+      |  beta = "bar",
+      |  gamma = false
+      |)"""
+
+    """foo(
+      |"foo",
+      |"bar",
+      |false)""" ==>
+    """foo(
+      |  "foo",
+      |  "bar",
+      |  false
+      |)"""
+  }
+
+  {
+    implicit val formattingPreferences = FormattingPreferences.setPreference(DanglingCloseParenthesis, Preserve)
+    """foo(
+      |alpha = "foo",
+      |beta = "bar",
+      |gamma = false)""" ==>
+    """foo(
+      |  alpha = "foo",
+      |  beta = "bar",
+      |  gamma = false)"""
+
+    """foo(
+      |alpha = "foo",
+      |beta = "bar",
+      |gamma = false
+      |)""" ==>
+    """foo(
+      |  alpha = "foo",
+      |  beta = "bar",
+      |  gamma = false
+      |)"""
+
+    """foo(
+      |"foo",
+      |"bar",
+      |false)""" ==>
+    """foo(
+      |  "foo",
+      |  "bar",
+      |  false)"""
+
+    """foo(
+      |"foo",
+      |"bar",
+      |false
+      |)""" ==>
+    """foo(
+      |  "foo",
+      |  "bar",
+      |  false
+      |)"""
+  }
+
+  {
+    implicit val formattingPreferences = FormattingPreferences.setPreference(DanglingCloseParenthesis, Prevent)
+    """foo(
+      |alpha = "foo",
+      |beta = "bar",
+      |gamma = false)""" ==>
+    """foo(
+      |  alpha = "foo",
+      |  beta = "bar",
+      |  gamma = false)"""
+
+    """foo(
+      |alpha = "foo",
+      |beta = "bar",
+      |gamma = false
+      |)""" ==>
+    """foo(
+      |  alpha = "foo",
+      |  beta = "bar",
+      |  gamma = false)"""
+
+    """foo(
+      |"foo",
+      |"bar",
+      |false)""" ==>
+    """foo(
+      |  "foo",
+      |  "bar",
+      |  false)"""
+
+    """foo(
+      |"foo",
+      |"bar",
+      |false
+      |)""" ==>
+    """foo(
+      |  "foo",
+      |  "bar",
+      |  false)"""
+  }
+
 }


### PR DESCRIPTION
This PR attempts to resolve https://github.com/daniel-trinh/scalariform/issues/29 by introducing a new trinary state preference `DanglingCloseParenthesis`. `DanglingCloseParenthesis = Prevent` should be equivalent to the old default behavior, `DanglingCloseParenthesis = Preserve` is equal to the old `PreserveDanglingCloseParenthesis = true`, and `DanglingCloseParenthesis = Force` is the current default behavior.