### PR TITLE
Fix multi-line indentation in more than call and match expressions.

### DIFF
--- a/scalariform/src/main/scala/com/danieltrinh/scalariform/formatter/ExprFormatter.scala
+++ b/scalariform/src/main/scala/com/danieltrinh/scalariform/formatter/ExprFormatter.scala
@@ -118,11 +118,10 @@ trait ExprFormatter { self: HasFormattingPreferences with AnnotationFormatter wi
             case (_, _: ArgumentExprs) if formattingPreferences(PreserveSpaceBeforeArguments) ⇒ CompactPreservingGap // TODO: Probably not needed now with CallExpr
             case (_, elem) if element.firstTokenOption exists { firstToken ⇒ newlineBefore(firstToken) && !(Set(COMMA, COLON) contains firstToken.tokenType) } ⇒
               val isNestedArgument = elem match {
-                case Argument(Expr(CallExpr(_, _, _, moreArgs, _) :: tail)) if moreArgs.isEmpty ⇒ false
+                case Argument(Expr(CallExpr(None, _, _, moreArgs, _) :: tail)) if moreArgs.isEmpty ⇒ false
                 case Argument(Expr(EqualsExpr(_, _, Expr(headExpr :: innerTail)) :: tail)) ⇒ headExpr match {
                   case CallExpr(children, _, _, moreArgs, _) ⇒ moreArgs.nonEmpty || headExpr.tokens.exists(tk => hiddenPredecessors(tk).containsNewline)
-                  case MatchExpr(_, _, _)                    ⇒ true
-                  case _                                     ⇒ false
+                  case _                                     ⇒ headExpr.tokens.exists(tk => hiddenPredecessors(tk).containsNewline)
                 }
                 case _ ⇒ true
               }

--- a/scalariform/src/test/scala/com/danieltrinh/scalariform/formatter/IndentWithTabsTest.scala
+++ b/scalariform/src/test/scala/com/danieltrinh/scalariform/formatter/IndentWithTabsTest.scala
@@ -129,6 +129,21 @@ class IndentWithTabsTest extends AbstractFormatterTest {
       |	"foo",
       |	"bar",
       |	false)"""
+
+    """sequence(
+      |authors.grouped(100).map(batch =>
+      |Object.get[List[SomeType]](
+      |Foo / "bar" / "baz" / "qux"
+      |)
+      |).toList
+      |).map(_.flatten)""" ==>
+    """sequence(
+      |	authors.grouped(100).map(batch =>
+      |		Object.get[List[SomeType]](
+      |			Foo / "bar" / "baz" / "qux"
+      |		)
+      |	).toList
+      |).map(_.flatten)"""
   }
 
   {


### PR DESCRIPTION
This fixes https://github.com/daniel-trinh/scalariform/issues/100 as well as a few more edge-cases. We were being a bit more specific than we needed to in the indentation code, this more general solution should work for all cases.