### PR TITLE
Fix CLI assembly

### DIFF
--- a/project/Build.scala
+++ b/project/Build.scala
@@ -25,7 +25,7 @@ object ScalariformBuild extends Build {
     organization := "org.scalariform",
     profileName := "org.scalariform",
     version := "0.1.8",
-    scalaVersion := "2.10.6",
+    scalaVersion := "2.11.7",
     crossScalaVersions := Seq(
       "2.11.7",
       "2.10.6",


### PR DESCRIPTION
fixes #109

The fix was to set the project's `scalaVersion` to same as latest `crossScalaVersion`.