### PR TITLE
Fix whitespace.

### DIFF
--- a/scalariform/src/main/scala/com/danieltrinh/scalariform/formatter/CommentFormatter.scala
+++ b/scalariform/src/main/scala/com/danieltrinh/scalariform/formatter/CommentFormatter.scala
@@ -8,12 +8,11 @@ import scala.annotation.tailrec
 
 trait CommentFormatter { self: HasFormattingPreferences with ScalaFormatter ⇒
 
-  private def getLines(comment: String): (String, List[String]) = {
+  private def getLines(comment: String, afterStarSpaces: Int): (String, List[String]) = {
     val prefix = List("/** ", "/**", "/* ", "/*").find(comment.startsWith).get
     val (start, rest) = comment.splitAt(prefix.length)
     val (contents, _) = rest.splitAt(rest.length - "*/".length)
     val firstLine :: otherLines = contents.split("""\r?\n([ \t]*(\*(?!/))?)?""", Integer.MAX_VALUE).toList
-    val afterStarSpaces = if (formattingPreferences(MultilineScaladocCommentsStartOnFirstLine)) 2 else 1
     val initialSpaces = firstLine takeWhile (_.isWhitespace)
     val adjustedLines = dropInitialSpaces(firstLine, initialSpaces.size) :: (otherLines map { dropInitialSpaces(_, afterStarSpaces) })
     //    val adjustedLines map { line ⇒ if (line startsWith "*/") "*" + line else line }
@@ -38,16 +37,20 @@ trait CommentFormatter { self: HasFormattingPreferences with ScalaFormatter ⇒
 
   def formatComment(comment: HiddenToken, indentLevel: Int): String =
     if (comment.rawText contains '\n') {
-      val sb = new StringBuilder
-      val (start, rawLines) = getLines(comment.rawText)
+      val alignBeneathSecondAsterisk = formattingPreferences(PlaceScaladocAsterisksBeneathSecondAsterisk)
+      val startOnFirstLine = formattingPreferences(MultilineScaladocCommentsStartOnFirstLine)
+      // Comments with right-justified asterisks always get one space. Left-justified asterisks get
+      // two spaces only if they also start on the first line.
+      val afterStarSpaces = if (alignBeneathSecondAsterisk || !startOnFirstLine) 1 else 2
+
+      val (start, rawLines) = getLines(comment.rawText, afterStarSpaces)
 
       val lines = pruneEmptyFinal(pruneEmptyInitial(rawLines))
 
-      val alignBeneathSecondAsterisk = formattingPreferences(PlaceScaladocAsterisksBeneathSecondAsterisk)
-      val startOnFirstLine = formattingPreferences(MultilineScaladocCommentsStartOnFirstLine)
-      val beforeStarSpaces = if (alignBeneathSecondAsterisk) "  " else " "
-      val afterStarSpaces = if (startOnFirstLine && !alignBeneathSecondAsterisk) "  " else " "
-      sb.append(start.trim)
+      val beforeStarSpacesString = if (alignBeneathSecondAsterisk) "  " else " "
+      val afterStarSpacesString = " " * afterStarSpaces
+
+      val sb = new StringBuilder(start.trim)
       var firstLine = true
       for (line ← lines) {
         val trimmedLine = removeTrailingWhitespace(line)
@@ -55,13 +58,13 @@ trait CommentFormatter { self: HasFormattingPreferences with ScalaFormatter ⇒
           if (trimmedLine.nonEmpty)
             sb.append(" ").append(trimmedLine)
         } else {
-          sb.append(newlineSequence).indent(indentLevel).append(beforeStarSpaces).append("*")
+          sb.append(newlineSequence).indent(indentLevel).append(beforeStarSpacesString).append("*")
           if (trimmedLine.nonEmpty)
-            sb.append(afterStarSpaces).append(trimmedLine)
+            sb.append(afterStarSpacesString).append(trimmedLine)
         }
         firstLine = false
       }
-      sb.append(newlineSequence).indent(indentLevel).append(beforeStarSpaces).append("*/")
+      sb.append(newlineSequence).indent(indentLevel).append(beforeStarSpacesString).append("*/")
       sb.toString
     } else
       comment.rawText

--- a/scalariform/src/test/scala/com/danieltrinh/scalariform/formatter/CommentFormatterTest.scala
+++ b/scalariform/src/test/scala/com/danieltrinh/scalariform/formatter/CommentFormatterTest.scala
@@ -181,6 +181,17 @@ class CommentFormatterTest extends AbstractFormatterTest {
     |  */
     |""" 
 
+  """/**
+    | * Scaladoc should be retained.
+    | * @param first line retains indent.
+    | *     second line retains indent.
+    | */""" ==>
+  """/** Scaladoc should be retained.
+    |  * @param first line retains indent.
+    |  *     second line retains indent.
+    |  */
+    |"""
+
   """/** Foo
     |Bar
     |*Baz  */""" ==>


### PR DESCRIPTION
This fixes a long-standing bug in how comments get autoformatted if you have the suggested Scaladoc style enabled. Note the unit test commit, which fails on `master`.

This manifested if you had > 1 space leading a scaladoc comment. The worst part was that the formatting would only remove *one* space at a time - meaning each subsequence scalariform run deleted one additional space.